### PR TITLE
First version of Naomi Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3.11.9-slim
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+ENV JASPER_CONFIG=/config
+
+COPY ../naomi-docker/apt_req.txt .
+RUN apt update -y  \
+    && apt upgrade -y  \
+    && awk '! /^ *(#|$)/' apt_req.txt | xargs -r -- apt install -y --no-install-recommends \
+    && apt clean \
+    && apt autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -u 1000 naomi  \
+    && usermod -aG sudo naomi  \
+    && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN mkdir /config
+
+RUN git clone https://github.com/NaomiProject/Naomi.git /Naomi/
+WORKDIR "/Naomi/"
+RUN pip install --upgrade pip
+
+COPY requirements.txt .
+RUN printf "Building for arch ${TARGETARCH}";
+RUN --mount=type=cache,target=/root/.cache/pip if [ "$TARGETARCH" = "amd64" ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    elif [ "$TARGETARCH$TARGETVARIANT" = "armv7" -o "$TARGETARCH" = "arm64" ]; then \
+        pip3 install --no-cache-dir --index-url=https://www.piwheels.org/simple --extra-index-url=https://pypi.python.org/simple/ --no-cache-dir -r requirements.txt \
+    ; fi
+
+RUN /Naomi/compile_translations.sh
+
+USER naomi
+
+CMD ["python", "Naomi.py", "--debug"]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 ENV JASPER_CONFIG=/config
 
-COPY ../naomi-docker/apt_req.txt .
+COPY apt_req.txt .
 RUN apt update -y  \
     && apt upgrade -y  \
     && awk '! /^ *(#|$)/' apt_req.txt | xargs -r -- apt install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ the right instructions to install and enable it on your device.
 
 ### Run Naomi docker 
 
+#### Classic method
 To start a container based on the image available on DockerHub :
 
 ```shell
@@ -30,6 +31,14 @@ docker run -it -d --name naomi-docker
     -v /host/path/to/config:/config/
     --env XDG_RUNTIME_DIR=/tmp 
     tuxseb/naomi-test:latest 
+```
+
+#### Docker compose 
+
+You can also use the provided docker compose file, `docker-compose.yml`.  
+
+```shell
+docker compose up
 ```
 
 ### Audio Setup 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ here's a tutorial [to set it up on your machine](https://www.baeldung.com/ops/do
 
 Once done, use: 
 
-```docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push --tag <Dockerhub repository> .```
+```shell
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push --tag <Dockerhub repository> .
+```
 
 Take note that you can change the platform argument following your needs.
 Depending on your CPU, it may take a while since Buildx needs to emulate the target architectures locally. # naomi-docker

--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
-# naomi-docker
+
+# Naomi Docker
+
+Naomi, dockerized. 
+
+This is the best way to install Naomi quickly and easily without altering the host system.
+
+## Prerequisites
+
+You need to install Docker on your host, [see instructions here](https://docs.docker.com/engine/install/). 
+
+Docker desktop **isn't** required. 
+
+You also need [Pipewire](https://pipewire.org/) as your host's sound server, at least **v1.0.7** on your device to use this container. 
+
+Raspberry Pi OS 12 (Bookworm) should be fine, since Pipewire is the new audio server by default since then. 
+
+To check if this is the case, use `pactl info` in your favourite terminal, if you see `PulseAudio (on PipeWire 1.0.7)` you're good, otherwise you'll need to find 
+the right instructions to install and enable it on your device. 
+
+## Production 
+
+### Run Naomi docker 
+
+To start a container based on the image available on DockerHub :
+
+```shell
+docker run -it -d --name naomi-docker
+    -v /run/user/1000/pipewire-0:/tmp/pipewire-0 
+    -v /host/path/to/config:/config/
+    --env XDG_RUNTIME_DIR=/tmp 
+    tuxseb/naomi-test:latest 
+```
+
+### Audio Setup 
+
+⚠️ On setup, use both audio input & output labeled `pipewire`, It'll use the microphone and speakers you picked on your host.
+
+Your `profile.yaml` entry for audio should look like this : 
+```shell
+audio:
+  input_chunksize: '1024'
+  input_device: pipewire
+  input_rate: '16000'
+  output_device: pipewire
+```
+
+## Development 
+
+If you want to build the image by yourself for development purposes or out of curiosity, here are the instructions.
+
+### Build image
+
+Clone this repository on your device and then:
+
+```Docker build --tag naomi-docker .```
+
+Then launch Naomi with :
+
+```shell
+docker run -it -d --name naomi-docker
+    -v /run/user/1000/pipewire-0:/tmp/pipewire-0 
+    -v /host/path/to/config:/config/
+    --env XDG_RUNTIME_DIR=/tmp 
+    naomi-docker 
+```
+
+See the setup part above for sound configuration with Pipewire. 
+
+### Multi arch build 
+
+To build multi architectures images locally (amd64, armv7, arm64...), you need to use [Docker Buildx](https://github.com/docker/buildx), 
+here's a tutorial [to set it up on your machine](https://www.baeldung.com/ops/docker-buildx). 
+
+Once done, use: 
+
+```docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push --tag <Dockerhub repository> .```
+
+Take note that you can change the platform argument following your needs.
+Depending on your CPU, it may take a while since Buildx needs to emulate the target architectures locally. # naomi-docker
 Naomi, dockerized. 

--- a/apt_req.txt
+++ b/apt_req.txt
@@ -9,6 +9,7 @@ g++
 gcc
 libopenblas-dev
 libffi-dev
+unzip
 
 # Naomi Core requirements
 alsa-utils

--- a/apt_req.txt
+++ b/apt_req.txt
@@ -1,0 +1,55 @@
+# Docker core requirements
+sudo
+pipewire
+pipewire-alsa
+git
+make
+automake
+g++
+gcc
+libopenblas-dev
+libffi-dev
+
+# Naomi Core requirements
+alsa-utils
+dirmngr
+gettext
+gfortran
+gnupg
+jq
+libatlas3-base
+libncurses5-dev
+libssl-dev
+util-linux
+
+# Plugins
+## AudioEngine
+### PyAudio
+libasound2-dev
+portaudio19-dev
+
+
+## STT
+### PocketSphinx is default for wakeword spotting
+pocketsphinx
+sphinxtrain
+
+### KenLM for building ARPA models
+build-essential
+cmake
+libboost-system-dev
+libboost-thread-dev
+libboost-program-options-dev
+libboost-test-dev
+libeigen3-dev
+zlib1g-dev
+libbz2-dev
+liblzma-dev
+
+# TTS
+## flite
+flite
+
+# SpeechHandler
+## MPDControl
+mpd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+---
+services:
+  naomi-docker:
+    container_name: naomi-docker
+    image: tuxseb/naomi-test:latest
+    tty: true
+    restart: no
+    volumes:
+      - /run/user/1000/pipewire-0:/tmp/pipewire-0
+      - /home/sebastien/.config/naomi:/config/
+    environment:
+      - XDG_RUNTIME_DIR=/tmp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,55 @@
+# Naomi core dependencies
+APScheduler
+argparse
+mock==3.0.5
+pytz
+PyYAML
+requests
+blessings
+pyaudio
+pyalsaaudio
+cryptography
+
+#other modules
+python-slugify
+mad
+
+# Pocketsphinx STT engine
+pocketsphinx
+
+# HN module
+semantic
+
+# Birthday/Notifications modules
+facebook-sdk
+
+# Weather/News modules
+feedparser
+
+# Gmail module
+python-dateutil
+
+# MPDControl module
+python-mpd2
+
+# google stt
+google-api-core
+google-auth
+google-cloud-speech
+googleapis-common-protos
+grpcio
+
+# google tts
+google-cloud-texttospeech
+
+# webrtcvad
+webrtcvad
+
+# NaomiSTTTrain
+cython
+pandas
+scikit-learn==1.4.2
+jiwer
+
+# Development
+flake8


### PR DESCRIPTION
With audio (input/output) using Pipewire & multi-arch support (AMD64, ARMv7 & ARM64)

**Notes:** 
- Python requirement is temporary included due to specified version scikit learn (currently 1.4.2), v1.5.0 and + being unavailable on ARMv7. Fix needed on the naomi repository.  
- Modified package requirement is included for compiling certain python dependencies and the use of pipewire instead of pulseaudio as sound server. 